### PR TITLE
feat(calendar): Add panels for calendar and summary

### DIFF
--- a/src/components/MonthSummary.vue
+++ b/src/components/MonthSummary.vue
@@ -1,129 +1,147 @@
 <template>
   <v-container class="ma-0 pa-0">
-    <v-card class="ma-3 pa-3">
+    <v-card flat>
       <v-card-title primary-title>
-        <div class="headline primary--text">Résumé</div>
+        <div class="headline primary--text">Afficher le mois {{ selectedMonthString }} {{ selectedYear }}</div>
       </v-card-title>
-
-      <v-card-text>
-        <v-list
-          dense
-        >
-          <v-list-item-group
-            color="primary"
-          >
-            <v-list-item
-              v-for="(day, i) in days"
-              :key="i"
-            >
-              <v-list-item-icon>
-                <v-icon v-text="day.icon"></v-icon>
-              </v-list-item-icon>
-
-              <v-list-item-content>
-                <v-list-item-title v-text="day.text"></v-list-item-title>
-              </v-list-item-content>
-
-              <v-list-item-icon>
-                {{ day.value }}
-              </v-list-item-icon>
-              
-            </v-list-item>
-          </v-list-item-group>
-        </v-list>
-
-        <v-list
-          dense
-        >
-          <v-subheader>Recapitulatif des jours</v-subheader>
-          <v-list-item-group
-            color="primary"
-          >
-            <v-list-item
-              v-for="(day, i) in daysRecap"
-              :key="i"
-            >
-              <v-list-item-icon>
-                <v-icon v-text="day.icon"></v-icon>
-              </v-list-item-icon>
-
-              <v-list-item-content>
-                <v-list-item-title v-text="day.text"></v-list-item-title>
-              </v-list-item-content>
-
-              <v-list-item-icon>
-                {{ day.value }}
-              </v-list-item-icon>
-              
-            </v-list-item>
-          </v-list-item-group>
-        </v-list>
-
-        <v-list
-          dense
-        >
-          <v-subheader>Recapitulatif des heures</v-subheader>
-          <v-list-item-group
-            color="primary"
-          >
-            <v-list-item
-              v-for="(hour, i) in hoursRecap"
-              :key="i"
-            >
-              <v-list-item-icon>
-                <v-icon v-text="hour.icon"></v-icon>
-              </v-list-item-icon>
-
-              <v-list-item-content>
-                <v-list-item-title v-text="hour.text"></v-list-item-title>
-              </v-list-item-content>
-
-              <v-list-item-icon>
-                {{ hour.value }}
-              </v-list-item-icon>
-              
-            </v-list-item>
-          </v-list-item-group>
-        </v-list>
-
-      </v-card-text>
-
     </v-card>
 
-
-    <v-card class="ma-3 pa-3">  
-      <v-card-title primary-title>
-        <div class="headline primary--text">Pajemploi</div>
-      </v-card-title>
-
-      <v-card-text>
-        <v-list
-          dense
-        >
-          <v-list-item-group
-            color="primary"
+    <v-container fluid>
+      <v-layout row wrap>
+        <v-flex xs12 md6>
+          <v-card
+            class="ma-3 pa-3"
           >
-            <v-list-item
-              v-for="(item, i) in pajeEmploi"
-              :key="i"
-            >
-              <v-list-item-icon>
-                <v-icon v-text="item.icon"></v-icon>
-              </v-list-item-icon>
+            <v-card-title primary-title>
+              <div class="headline primary--text">Résumé</div>
+            </v-card-title>
 
-              <v-list-item-content>
-                <v-list-item-title v-text="item.text"></v-list-item-title>
-              </v-list-item-content>
+            <v-card-text>
+              <v-list
+                dense
+              >
+                <v-list-item-group
+                  color="primary"
+                >
+                  <v-list-item
+                    v-for="(day, i) in days"
+                    :key="i"
+                  >
+                    <v-list-item-icon>
+                      <v-icon v-text="day.icon"></v-icon>
+                    </v-list-item-icon>
 
-              <v-list-item-icon>
-                {{ item.value }}
-              </v-list-item-icon>
-              
-            </v-list-item>
-          </v-list-item-group>
-        </v-list>
-      </v-card-text>
-    </v-card>
+                    <v-list-item-content>
+                      <v-list-item-title v-text="day.text"></v-list-item-title>
+                    </v-list-item-content>
+
+                    <v-list-item-icon>
+                      {{ day.value }}
+                    </v-list-item-icon>
+
+                  </v-list-item>
+                </v-list-item-group>
+              </v-list>
+
+              <v-list
+                dense
+              >
+                <v-subheader>Recapitulatif des jours</v-subheader>
+                <v-list-item-group
+                  color="primary"
+                >
+                  <v-list-item
+                    v-for="(day, i) in daysRecap"
+                    :key="i"
+                  >
+                    <v-list-item-icon>
+                      <v-icon v-text="day.icon"></v-icon>
+                    </v-list-item-icon>
+
+                    <v-list-item-content>
+                      <v-list-item-title v-text="day.text"></v-list-item-title>
+                    </v-list-item-content>
+
+                    <v-list-item-icon>
+                      {{ day.value }}
+                    </v-list-item-icon>
+
+                  </v-list-item>
+                </v-list-item-group>
+              </v-list>
+
+              <v-list
+                dense
+              >
+                <v-subheader>Recapitulatif des heures</v-subheader>
+                <v-list-item-group
+                  color="primary"
+                >
+                  <v-list-item
+                    v-for="(hour, i) in hoursRecap"
+                    :key="i"
+                  >
+                    <v-list-item-icon>
+                      <v-icon v-text="hour.icon"></v-icon>
+                    </v-list-item-icon>
+
+                    <v-list-item-content>
+                      <v-list-item-title v-text="hour.text"></v-list-item-title>
+                    </v-list-item-content>
+
+                    <v-list-item-icon>
+                      {{ hour.value }}
+                    </v-list-item-icon>
+
+                  </v-list-item>
+                </v-list-item-group>
+              </v-list>
+
+            </v-card-text>
+
+          </v-card>
+        </v-flex>
+        <v-flex xs12 md6>
+
+          <v-card
+            class="ma-3 pa-3"
+          >
+            <v-card-title primary-title>
+              <div class="headline primary--text">Pajemploi</div>
+            </v-card-title>
+
+            <v-card-text>
+              <v-list
+                dense
+              >
+                <v-list-item-group
+                  color="primary"
+                >
+                  <v-list-item
+                    v-for="(item, i) in pajeEmploi"
+                    :key="i"
+                  >
+                    <v-list-item-icon>
+                      <v-icon v-text="item.icon"></v-icon>
+                    </v-list-item-icon>
+
+                    <v-list-item-content>
+                      <v-list-item-title v-text="item.text"></v-list-item-title>
+                    </v-list-item-content>
+
+                    <v-list-item-icon>
+                      {{ item.value }}
+                    </v-list-item-icon>
+
+                  </v-list-item>
+                </v-list-item-group>
+              </v-list>
+            </v-card-text>
+          </v-card>
+
+        </v-flex>
+      </v-layout>
+    </v-container>
 
   </v-container>
 

--- a/src/views/main/contracts/UserContractCalendar.vue
+++ b/src/views/main/contracts/UserContractCalendar.vue
@@ -1,206 +1,218 @@
 <template>
   <v-container fluid>
     <v-row no-gutters>
-      <v-col cols="12" md="12" lg="9" >
-        <v-card class="ma-3 pa-3">
-          <v-card-title primary-title>
-            <div class="headline primary--text">Modifier le calendrier</div>
-          </v-card-title>
-          <v-card-text>
-            <h3 ref="selectedMonth">{{ selectedMonthString }} {{ selectedYear }}</h3>
-            <v-layout wrap>
-              <v-flex xs12>
-                <v-sheet height="600">
-                  <v-calendar
-                    ref="calendar"
-                    v-model="calendar"
-                    color="primary"
-                    :value="selectedDate"
-                    :event-color="getEventColor"
-                    :type="type"
-                    :weekdays="weekdays"
-                    :show-week='true'
-                    :events="events"
-                    @change="updateRange"
-                    @click:event="addEvent"
-                    @click:day="addEvent"
-                    @click:date="addEvent"
-                  >
-                  </v-calendar>
+      <v-tabs
+        grow
+      >
+        <v-tab>
+          Calendrier
+        </v-tab>
+        <v-tab>
+          Récapitulatif du mois
+        </v-tab>
 
-                  <v-dialog
-                    v-model="newOpen"
-                    :close-on-content-click="false"
-                    :activator="newElement"
-                    offset-x
-                    min-width="200"
-                    max-width="700"
-                  >
-                    <v-card
-                      color="grey lighten-4"
-                      flat
+        <v-tab-item>
+          <v-card
+            flat
+          >
+            <v-card-title primary-title>
+              <div class="headline primary--text">{{ selectedMonthString }} {{ selectedYear }}</div>
+            </v-card-title>
+            <v-card-text>
+              <v-layout wrap>
+                <v-flex xs12>
+                  <v-sheet height="600">
+                    <v-calendar
+                      ref="calendar"
+                      v-model="calendar"
+                      color="primary"
+                      :value="selectedDate"
+                      :event-color="getEventColor"
+                      :type="type"
+                      :weekdays="weekdays"
+                      :show-week='true'
+                      :events="events"
+                      @change="updateRange"
+                      @click:event="addEvent"
+                      @click:day="addEvent"
+                      @click:date="addEvent"
                     >
-                      <v-toolbar
-                        dark
+                    </v-calendar>
+
+                    <v-dialog
+                      v-model="newOpen"
+                      :close-on-content-click="false"
+                      :activator="newElement"
+                      offset-x
+                      min-width="200"
+                      max-width="700"
+                    >
+                      <v-card
+                        color="grey lighten-4"
+                        flat
                       >
-                        <v-toolbar-title>Ajouter une journée</v-toolbar-title>
-                        <v-spacer></v-spacer>
-                        <v-btn
-                          icon
-                          @click="addEventClose"
+                        <v-toolbar
+                          dark
                         >
-                          <v-icon>mdi-close</v-icon>
-                        </v-btn>
-                      </v-toolbar>
-                      <v-card-text>
-                        <p></p>
-                        <div class="text--primary">
-                          <v-row align="center">
-                            <v-col cols="6">
-                              <v-subheader>
-                                Date
-                              </v-subheader>
-                            </v-col>
+                          <v-toolbar-title>Ajouter une journée</v-toolbar-title>
+                          <v-spacer></v-spacer>
+                          <v-btn
+                            icon
+                            @click="addEventClose"
+                          >
+                            <v-icon>mdi-close</v-icon>
+                          </v-btn>
+                        </v-toolbar>
+                        <v-card-text>
+                          <p></p>
+                          <div class="text--primary">
+                            <v-row align="center">
+                              <v-col cols="6">
+                                <v-subheader>
+                                  Date
+                                </v-subheader>
+                              </v-col>
 
-                            <v-col cols="6">
-                              {{ newEvent.date }}
-                            </v-col>
-                          </v-row>
-                          <v-row align="center">
-                            <v-col cols="6">
-                              <v-subheader>
-                                Type de la journée
-                              </v-subheader>
-                            </v-col>
+                              <v-col cols="6">
+                                {{ newEvent.date }}
+                              </v-col>
+                            </v-row>
+                            <v-row align="center">
+                              <v-col cols="6">
+                                <v-subheader>
+                                  Type de la journée
+                                </v-subheader>
+                              </v-col>
 
-                            <v-col cols="6">
-                              <v-select
-                                v-model="newEvent.dayType"
-                                :items="dayTypes.slice(2)"
-                                item-text="name"
-                                item-value="name"
-                                label="Choisissez..."
-                                persistent-hint
-                                return-object
-                                single-line
-                              ></v-select>
-                            </v-col>
-                          </v-row>
-                          <v-row align="center" v-if="[3].includes(newEvent.dayType.id)">
-                            <v-col cols="6">
-                              <v-subheader>
-                                Heure de début
-                              </v-subheader>
-                            </v-col>
+                              <v-col cols="6">
+                                <v-select
+                                  v-model="newEvent.dayType"
+                                  :items="dayTypes.slice(2)"
+                                  item-text="name"
+                                  item-value="name"
+                                  label="Choisissez..."
+                                  persistent-hint
+                                  return-object
+                                  single-line
+                                ></v-select>
+                              </v-col>
+                            </v-row>
+                            <v-row align="center" v-if="[3].includes(newEvent.dayType.id)">
+                              <v-col cols="6">
+                                <v-subheader>
+                                  Heure de début
+                                </v-subheader>
+                              </v-col>
 
-                            <v-col cols="2">
-                              <v-select
-                                v-model="newEvent.hours.start.hour"
-                                :items="hoursList"
-                                label="Heure"
-                                persistent-hint
-                                return-object
-                                single-line
-                              ></v-select>
-                            </v-col>
-                            <v-col cols="2">
-                              <v-select
-                                v-model="newEvent.hours.start.minutes"
-                                :items="minutesList"
-                                label="Minute"
-                                persistent-hint
-                                return-object
-                                single-line
-                              ></v-select>
-                            </v-col>
-                          </v-row>
-                          <v-row align="center" v-if="[3].includes(newEvent.dayType.id)">
-                            <v-col cols="6">
-                              <v-subheader>
-                                Heure de fin
-                              </v-subheader>
-                            </v-col>
+                              <v-col cols="2">
+                                <v-select
+                                  v-model="newEvent.hours.start.hour"
+                                  :items="hoursList"
+                                  label="Heure"
+                                  persistent-hint
+                                  return-object
+                                  single-line
+                                ></v-select>
+                              </v-col>
+                              <v-col cols="2">
+                                <v-select
+                                  v-model="newEvent.hours.start.minutes"
+                                  :items="minutesList"
+                                  label="Minute"
+                                  persistent-hint
+                                  return-object
+                                  single-line
+                                ></v-select>
+                              </v-col>
+                            </v-row>
+                            <v-row align="center" v-if="[3].includes(newEvent.dayType.id)">
+                              <v-col cols="6">
+                                <v-subheader>
+                                  Heure de fin
+                                </v-subheader>
+                              </v-col>
 
-                            <v-col cols="2">
-                              <v-select
-                                v-model="newEvent.hours.end.hour"
-                                :items="hoursList"
-                                label="Heure"
-                                persistent-hint
-                                return-object
-                                single-line
-                              ></v-select>
-                            </v-col>
-                            <v-col cols="2">
-                              <v-select
-                                v-model="newEvent.hours.end.minutes"
-                                :items="minutesList"
-                                label="Minute"
-                                persistent-hint
-                                return-object
-                                single-line
-                              ></v-select>
-                            </v-col>
-                          </v-row>
-                        </div>
-                      </v-card-text>
-                      <v-card-actions>
-                        <v-btn
-                          text
-                          color="secondary"
-                          @click="addCalendarEvent"
-                        >
-                          Ajouter
-                        </v-btn>
-                        <v-btn
-                          text
-                          color="secondary"
-                          @click="addEventClose"
-                        >
-                          Fermer
-                        </v-btn>
-                      </v-card-actions>
-                    </v-card>
-                  </v-dialog>
-                </v-sheet>
-              </v-flex>
+                              <v-col cols="2">
+                                <v-select
+                                  v-model="newEvent.hours.end.hour"
+                                  :items="hoursList"
+                                  label="Heure"
+                                  persistent-hint
+                                  return-object
+                                  single-line
+                                ></v-select>
+                              </v-col>
+                              <v-col cols="2">
+                                <v-select
+                                  v-model="newEvent.hours.end.minutes"
+                                  :items="minutesList"
+                                  label="Minute"
+                                  persistent-hint
+                                  return-object
+                                  single-line
+                                ></v-select>
+                              </v-col>
+                            </v-row>
+                          </div>
+                        </v-card-text>
+                        <v-card-actions>
+                          <v-btn
+                            text
+                            color="secondary"
+                            @click="addCalendarEvent"
+                          >
+                            Ajouter
+                          </v-btn>
+                          <v-btn
+                            text
+                            color="secondary"
+                            @click="addEventClose"
+                          >
+                            Fermer
+                          </v-btn>
+                        </v-card-actions>
+                      </v-card>
+                    </v-dialog>
+                  </v-sheet>
+                </v-flex>
 
-              <v-flex sm4 xs12 class="text-sm-left text-xs-center">
-                <v-btn @click="$refs.calendar.prev()">
-                  <v-icon
-                    dark
-                    left
-                  >
-                    mdi-arrow-left
-                  </v-icon>
-                  Précédent
-                </v-btn>
-              </v-flex>
-              <v-flex sm4 xs12 class="text-xs-center">
-                <v-select v-model="type" :items="typeOptions" label="Type"></v-select>
-              </v-flex>
-              <v-flex
-                sm4
-                xs12
-                class="text-sm-right text-xs-center"
-              >
-                <v-btn @click="$refs.calendar.next()">
-                  Suivant
-                  <v-icon
-                    right
-                    dark
-                  >
-                    mdi-arrow-right
-                  </v-icon>
-                </v-btn>
-              </v-flex>
-            </v-layout>
-          </v-card-text>
-        </v-card>
-      </v-col>
-      <v-col>
-        <MonthSummary :summary="summary"/>
-      </v-col>
+                <v-flex sm4 xs12 class="text-sm-left text-xs-center">
+                  <v-btn @click="$refs.calendar.prev()">
+                    <v-icon
+                      dark
+                      left
+                    >
+                      mdi-arrow-left
+                    </v-icon>
+                    Précédent
+                  </v-btn>
+                </v-flex>
+                <v-flex sm4 xs12 class="text-xs-center">
+                  <v-select v-model="type" :items="typeOptions" label="Type"></v-select>
+                </v-flex>
+                <v-flex
+                  sm4
+                  xs12
+                  class="text-sm-right text-xs-center"
+                >
+                  <v-btn @click="$refs.calendar.next()">
+                    Suivant
+                    <v-icon
+                      right
+                      dark
+                    >
+                      mdi-arrow-right
+                    </v-icon>
+                  </v-btn>
+                </v-flex>
+              </v-layout>
+            </v-card-text>
+          </v-card>
+        </v-tab-item>
+        <v-tab-item>
+          <MonthSummary :summary="summary" />
+        </v-tab-item>
+      </v-tabs>
     </v-row>
   </v-container>
 </template>
@@ -245,6 +257,11 @@ interface Event {
   },
 })
 export default class UserContractCalendar extends Vue {
+  public tabs = {
+    sections: ['Calendrier', 'Récapitulatif'],
+    current: null,
+  };
+
   public valid = true;
   public userId: number = 0;
   public contractId: number | null = null;


### PR DESCRIPTION
Reste à faire : 
* Afficher la date (mois année) dans l'onglet Récapitulatif
* Gérer le dimensionnement des cards dans l'onglet Récapitulatif. Les cards se figent au dela d'une certaine taille, alors qu'il se redivisent correctement en plein écran